### PR TITLE
Cap FPS at 60

### DIFF
--- a/src/controllers/event_loop.py
+++ b/src/controllers/event_loop.py
@@ -14,7 +14,7 @@ def event_loop() -> None:
 
     window = Window()
 
-    player = Player([2, 2])
+    player = Player([200, 200])
     window.register_entity(player)
 
     # Event loop: a loop that checks if new events have occurred and responds to them if they have

--- a/src/models/entity.py
+++ b/src/models/entity.py
@@ -7,7 +7,7 @@ class Entity(metaclass=abc.ABCMeta):
     """Interface for any entity that can be managed by the window (i.e. a projectile, the player, etc."""
 
     @abc.abstractmethod
-    def move(self) -> None:
+    def move(self, delta_time) -> None:
         """Move the entity across the window."""
         raise NotImplementedError
 

--- a/src/models/entity.py
+++ b/src/models/entity.py
@@ -7,7 +7,7 @@ class Entity(metaclass=abc.ABCMeta):
     """Interface for any entity that can be managed by the window (i.e. a projectile, the player, etc."""
 
     @abc.abstractmethod
-    def move(self, delta_time) -> None:
+    def move(self, delta_time=1) -> None:
         """Move the entity across the window."""
         raise NotImplementedError
 

--- a/src/models/player.py
+++ b/src/models/player.py
@@ -18,7 +18,7 @@ class Player(Entity):
             raise RuntimeError(f"Invalid speed. Expected list of length 2, got length {len(speed)}")
         self.speed = speed
 
-    def move(self, delta_time):
+    def move(self, delta_time=1):
         """Moves the player according to their current speed."""
         self._player_rect = self._player_rect.move(self.speed[0] * delta_time, self.speed[1] * delta_time)
 

--- a/src/models/player.py
+++ b/src/models/player.py
@@ -18,9 +18,9 @@ class Player(Entity):
             raise RuntimeError(f"Invalid speed. Expected list of length 2, got length {len(speed)}")
         self.speed = speed
 
-    def move(self):
+    def move(self, delta_time):
         """Moves the player according to their current speed."""
-        self._player_rect = self._player_rect.move(self.speed)
+        self._player_rect = self._player_rect.move(self.speed[0] * delta_time, self.speed[1] * delta_time)
 
     def get_left(self):
         """Returns the player's left-most position."""

--- a/src/models/window.py
+++ b/src/models/window.py
@@ -36,7 +36,7 @@ class Window:
     def update(self):
         """Updates the contents of the entire window."""
         # tick the clock to ensure that the game runs at the target FPS
-        delta_time = self._clock.tick(TARGET_FPS) / 16.666666666666668
+        delta_time = self._clock.tick(TARGET_FPS) / 1000
         for entity in self._entities:
             # any motion should be multiplied by delta_time to ensure it isn't affected by framerate
             entity.move(delta_time)

--- a/src/models/window.py
+++ b/src/models/window.py
@@ -1,12 +1,13 @@
 from typing import List
 
-from pygame import Color, Surface, display
+from pygame import Color, Surface, display, time
 
 from models.entity import Entity
 
 DEFAULT_HEIGHT = 300
 DEFAULT_WIDTH  = 420
 MARGIN_FACTOR  = 0.9
+TARGET_FPS = 60
 
 INFO_ERROR = -1
 
@@ -15,6 +16,7 @@ class Window:
     """Represents the entire window that the game is rendered in."""
     _window_surface: Surface = None
     _entities: List[Entity] = []
+    _clock: time.Clock = time.Clock()
 
     def __init__(self):
         """Create a Window."""
@@ -43,6 +45,8 @@ class Window:
             self._window_surface.blit(entity.get_surface(), entity.get_rect())
         # flip redraws the window
         display.flip()
+        # tick the clock to ensure that the game runs at the target FPS
+        self._clock.tick(TARGET_FPS)
 
     def register_entity(self, entity: Entity):
         """Register a new entity to be managed by the window."""

--- a/src/models/window.py
+++ b/src/models/window.py
@@ -35,8 +35,11 @@ class Window:
 
     def update(self):
         """Updates the contents of the entire window."""
+        # tick the clock to ensure that the game runs at the target FPS
+        delta_time = self._clock.tick(TARGET_FPS) / 16.666666666666668
         for entity in self._entities:
-            entity.move()
+            # any motion should be multiplied by delta_time to ensure it isn't affected by framerate
+            entity.move(delta_time)
             if entity.get_left() <= 0 or entity.get_right() >= self._width:
                 entity.handle_window_border_x()
             if entity.get_top() <= 0 or entity.get_bottom() >= self._height:
@@ -45,8 +48,6 @@ class Window:
             self._window_surface.blit(entity.get_surface(), entity.get_rect())
         # flip redraws the window
         display.flip()
-        # tick the clock to ensure that the game runs at the target FPS
-        self._clock.tick(TARGET_FPS)
 
     def register_entity(self, entity: Entity):
         """Register a new entity to be managed by the window."""


### PR DESCRIPTION
FPS is limited to 60 by the pygame object `time.Clock`. This returns a value `delta_time` which any movement values should be multiplied by to correct for variation in framerate. Closes #5.

`player.py`:
```python
def move(self, delta_time):
    """Moves the player according to their current speed."""
    self._player_rect = self._player_rect.move(self.speed[0] * delta_time, self.speed[1] * delta_time)
```